### PR TITLE
Moves isolation segment resources into a module

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -36,15 +36,6 @@ resource "azurerm_dns_a_record" "sys" {
   records             = ["${azurerm_public_ip.web-lb-public-ip.ip_address}"]
 }
 
-resource "azurerm_dns_a_record" "iso" {
-  name                = "*.iso"
-  zone_name           = "${azurerm_dns_zone.env_dns_zone.name}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  ttl                 = "60"
-  records             = ["${azurerm_public_ip.iso-lb-public-ip.ip_address}"]
-  count               = "${var.create_isoseg_resources}"
-}
-
 resource "azurerm_dns_a_record" "mysql" {
   name                = "mysql"
   zone_name           = "${azurerm_dns_zone.env_dns_zone.name}"

--- a/isolation_segment/dns.tf
+++ b/isolation_segment/dns.tf
@@ -1,0 +1,8 @@
+resource "azurerm_dns_a_record" "iso" {
+  name                = "*.iso"
+  count               = "${var.count}"
+  zone_name           = "${var.dns_zone}"
+  resource_group_name = "${var.resource_group_name}"
+  ttl                 = "60"
+  records             = ["${azurerm_public_ip.iso-lb-public-ip.ip_address}"]
+}

--- a/isolation_segment/load_balancer.tf
+++ b/isolation_segment/load_balancer.tf
@@ -1,21 +1,16 @@
-/************************
- * Isolation Segment LB *
- ************************/
-
 resource "azurerm_public_ip" "iso-lb-public-ip" {
   name                         = "iso-lb-public-ip"
+  count                        = "${var.count}"
   location                     = "${var.location}"
-  resource_group_name          = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name          = "${var.resource_group_name}"
   public_ip_address_allocation = "static"
-
-  count = "${var.create_isoseg_resources}"
 }
 
 resource "azurerm_lb" "iso" {
-  name                = "${var.env_name}-iso-lb"
+  name                = "${var.environment}-iso-lb"
+  count               = "${var.count}"
   location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  count               = "${var.create_isoseg_resources}"
+  resource_group_name = "${var.resource_group_name}"
 
   frontend_ip_configuration = {
     name                 = "frontendip"
@@ -25,26 +20,24 @@ resource "azurerm_lb" "iso" {
 
 resource "azurerm_lb_backend_address_pool" "iso-backend-pool" {
   name                = "iso-backend-pool"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  count               = "${var.count}"
+  resource_group_name = "${var.resource_group_name}"
   loadbalancer_id     = "${azurerm_lb.iso.id}"
-  count               = "${var.create_isoseg_resources}"
 }
 
 resource "azurerm_lb_probe" "iso-https-probe" {
   name                = "iso-https-probe"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  count               = "${var.count}"
+  resource_group_name = "${var.resource_group_name}"
   loadbalancer_id     = "${azurerm_lb.iso.id}"
   protocol            = "TCP"
   port                = 443
-  count               = "${var.create_isoseg_resources}"
 }
 
 resource "azurerm_lb_rule" "iso-https-rule" {
   name                = "iso-https-rule"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  count               = "${var.count}"
+  resource_group_name = "${var.resource_group_name}"
   loadbalancer_id     = "${azurerm_lb.iso.id}"
 
   frontend_ip_configuration_name = "frontendip"
@@ -54,23 +47,21 @@ resource "azurerm_lb_rule" "iso-https-rule" {
 
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.iso-backend-pool.id}"
   probe_id                = "${azurerm_lb_probe.iso-https-probe.id}"
-  count                   = "${var.create_isoseg_resources}"
 }
 
 resource "azurerm_lb_probe" "iso-http-probe" {
   name                = "iso-http-probe"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  count               = "${var.count}"
+  resource_group_name = "${var.resource_group_name}"
   loadbalancer_id     = "${azurerm_lb.iso.id}"
   protocol            = "TCP"
   port                = 80
-  count               = "${var.create_isoseg_resources}"
 }
 
 resource "azurerm_lb_rule" "iso-http-rule" {
   name                = "iso-http-rule"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  count               = "${var.count}"
+  resource_group_name = "${var.resource_group_name}"
   loadbalancer_id     = "${azurerm_lb.iso.id}"
 
   frontend_ip_configuration_name = "frontendip"
@@ -80,5 +71,4 @@ resource "azurerm_lb_rule" "iso-http-rule" {
 
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.iso-backend-pool.id}"
   probe_id                = "${azurerm_lb_probe.iso-http-probe.id}"
-  count                   = "${var.create_isoseg_resources}"
 }

--- a/isolation_segment/outputs.tf
+++ b/isolation_segment/outputs.tf
@@ -1,0 +1,3 @@
+output "lb_name" {
+  value = "${azurerm_lb.iso.name}"
+}

--- a/isolation_segment/variables.tf
+++ b/isolation_segment/variables.tf
@@ -1,0 +1,17 @@
+variable "count" {}
+
+variable "location" {
+  type = "string"
+}
+
+variable "environment" {
+  type = "string"
+}
+
+variable "resource_group_name" {
+  type = "string"
+}
+
+variable "dns_zone" {
+  type = "string"
+}

--- a/modules.tf
+++ b/modules.tf
@@ -1,0 +1,10 @@
+module "isolation_segment" {
+  source = "./isolation_segment"
+
+  count = "${var.isolation_segment ? 1 : 0}"
+
+  environment         = "${var.env_name}"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  dns_zone            = "${azurerm_dns_zone.env_dns_zone.name}"
+}

--- a/mysqllb.tf
+++ b/mysqllb.tf
@@ -11,14 +11,12 @@ resource "azurerm_lb" "mysql" {
 
 resource "azurerm_lb_backend_address_pool" "mysql-backend-pool" {
   name                = "mysql-backend-pool"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.mysql.id}"
 }
 
 resource "azurerm_lb_probe" "mysql-probe" {
   name                = "mysql-probe"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.mysql.id}"
   protocol            = "TCP"
@@ -27,7 +25,6 @@ resource "azurerm_lb_probe" "mysql-probe" {
 
 resource "azurerm_lb_rule" "mysql-rule" {
   name                = "mysql-rule"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.mysql.id}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,10 +54,6 @@ output "tcp_lb_name" {
   value = "${azurerm_lb.tcp.name}"
 }
 
-output "isoseg_lb_name" {
-  value = "${azurerm_lb.iso.name}"
-}
-
 output "network_name" {
   value = "${azurerm_virtual_network.pcf_virtual_network.name}"
 }
@@ -152,4 +148,10 @@ output "ops_manager_ssh_private_key" {
 
 output "ops_manager_public_ip" {
   value = "${azurerm_public_ip.ops_manager_public_ip.ip_address}"
+}
+
+output "isolation_segment" {
+  value = {
+    "lb_name" = "${module.isolation_segment.lb_name}"
+  }
 }

--- a/tcplb.tf
+++ b/tcplb.tf
@@ -18,14 +18,12 @@ resource "azurerm_lb" "tcp" {
 
 resource "azurerm_lb_backend_address_pool" "tcp-backend-pool" {
   name                = "tcp-backend-pool"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.tcp.id}"
 }
 
 resource "azurerm_lb_probe" "tcp-probe" {
   name                = "tcp-probe"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.tcp.id}"
   protocol            = "TCP"
@@ -35,7 +33,6 @@ resource "azurerm_lb_probe" "tcp-probe" {
 resource "azurerm_lb_rule" "tcp-rule" {
   count               = 150
   name                = "tcp-rule-${count.index + 1024}"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.tcp.id}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "vm_admin_password" {}
 
 variable "dns_suffix" {}
 
-/*************************************
- * Optional Isolation Segment Config *
- *************************************/
-
-variable "create_isoseg_resources" {
-  type        = "string"
-  default     = "0"
-  description = "Optionally create a LB and DNS entries for a single isolation segment. Valid values are 0 or 1."
+variable "isolation_segment" {
+  default = false
 }

--- a/weblb.tf
+++ b/weblb.tf
@@ -18,14 +18,12 @@ resource "azurerm_lb" "web" {
 
 resource "azurerm_lb_backend_address_pool" "web-backend-pool" {
   name                = "web-backend-pool"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
 }
 
 resource "azurerm_lb_probe" "web-https-probe" {
   name                = "web-https-probe"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
   protocol            = "TCP"
@@ -34,7 +32,6 @@ resource "azurerm_lb_probe" "web-https-probe" {
 
 resource "azurerm_lb_rule" "web-https-rule" {
   name                = "web-https-rule"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
 
@@ -49,7 +46,6 @@ resource "azurerm_lb_rule" "web-https-rule" {
 
 resource "azurerm_lb_probe" "web-http-probe" {
   name                = "web-http-probe"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
   protocol            = "TCP"
@@ -58,7 +54,6 @@ resource "azurerm_lb_probe" "web-http-probe" {
 
 resource "azurerm_lb_rule" "web-http-rule" {
   name                = "web-http-rule"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
 
@@ -73,7 +68,6 @@ resource "azurerm_lb_rule" "web-http-rule" {
 
 resource "azurerm_lb_probe" "web-ssh-probe" {
   name                = "web-ssh-probe"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
   protocol            = "TCP"
@@ -82,7 +76,6 @@ resource "azurerm_lb_probe" "web-ssh-probe" {
 
 resource "azurerm_lb_rule" "web-ssh-rule" {
   name                = "web-ssh-rule"
-  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   loadbalancer_id     = "${azurerm_lb.web.id}"
 


### PR DESCRIPTION
Here is a spike I worked on to try out cleaning up some of our stuff using modules. To me, the advantages here are pretty good.

1. the code for a set of resources is confined to a directory and not all over the place
1. you can have a pretty "API" for using the module: saying `isolation_segment = true` instead of `create_isoseg_resources = 1`
1. you can namespace your outputs: all of the isolation segment outputs can be grouped together