### PR TITLE
[#142867449] Increase the number of storage accounts from 3 to 5

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -64,7 +64,7 @@ resource "azurerm_storage_account" "bosh_vms_storage_account" {
   location            = "${var.location}"
   account_type        = "Premium_LRS"
 
-  count = 3
+  count = 5
 }
 
 resource "azurerm_storage_container" "bosh_vms_storage_container" {
@@ -74,7 +74,7 @@ resource "azurerm_storage_container" "bosh_vms_storage_container" {
   storage_account_name  = "${element(azurerm_storage_account.bosh_vms_storage_account.*.name, count.index)}"
   container_access_type = "private"
 
-  count = 3
+  count = 5
 }
 
 resource "azurerm_storage_container" "bosh_vms_stemcell_storage_container" {
@@ -84,7 +84,7 @@ resource "azurerm_storage_container" "bosh_vms_stemcell_storage_container" {
   storage_account_name  = "${element(azurerm_storage_account.bosh_vms_storage_account.*.name, count.index)}"
   container_access_type = "private"
 
-  count = 3
+  count = 5
 }
 
 # Storage containers to be used as CF Blobstore


### PR DESCRIPTION
Azure bosh cpi limits the number of disks created in a storage account to 32. With the number of tiles we install (approximately 12 and increasing), we are hitting this limit and our installations fails. 

See tracker story for details.
https://www.pivotaltracker.com/story/show/142867449