### PR TITLE
 Rename  ERT Resources to PAS for Consistency

### DIFF
--- a/mysqllb.tf
+++ b/mysqllb.tf
@@ -5,7 +5,7 @@ resource "azurerm_lb" "mysql" {
 
   frontend_ip_configuration = {
     name      = "frontendip"
-    subnet_id = "${azurerm_subnet.ert_subnet.id}"
+    subnet_id = "${azurerm_subnet.pas_subnet.id}"
   }
 }
 

--- a/networks.tf
+++ b/networks.tf
@@ -14,8 +14,8 @@ resource "azurerm_subnet" "management_subnet" {
   address_prefix       = "10.0.8.0/26"
 }
 
-resource "azurerm_subnet" "ert_subnet" {
-  name                 = "${var.env_name}-ert-subnet"
+resource "azurerm_subnet" "pas_subnet" {
+  name                 = "${var.env_name}-pas-subnet"
   depends_on           = ["azurerm_resource_group.pcf_resource_group"]
   resource_group_name  = "${azurerm_resource_group.pcf_resource_group.name}"
   virtual_network_name = "${azurerm_virtual_network.pcf_virtual_network.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,16 +70,16 @@ output "management_subnet_gateway" {
   value = "${cidrhost(azurerm_subnet.management_subnet.address_prefix, 1)}"
 }
 
-output "ert_subnet_name" {
-  value = "${azurerm_subnet.ert_subnet.name}"
+output "pas_subnet_name" {
+  value = "${azurerm_subnet.pas_subnet.name}"
 }
 
-output "ert_subnet_cidrs" {
-  value = ["${azurerm_subnet.ert_subnet.address_prefix}"]
+output "pas_subnet_cidrs" {
+  value = ["${azurerm_subnet.pas_subnet.address_prefix}"]
 }
 
-output "ert_subnet_gateway" {
-  value = "${cidrhost(azurerm_subnet.ert_subnet.address_prefix, 1)}"
+output "pas_subnet_gateway" {
+  value = "${cidrhost(azurerm_subnet.pas_subnet.address_prefix, 1)}"
 }
 
 output "services_subnet_name" {

--- a/storage.tf
+++ b/storage.tf
@@ -1,15 +1,17 @@
 resource "azurerm_storage_account" "bosh_root_storage_account" {
-  name                = "${var.env_short_name}director"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  location            = "${var.location}"
-  account_type        = "Standard_LRS"
+  name                     = "${var.env_short_name}director"
+  resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_account" "ops_manager_storage_account" {
-  name                = "${var.env_short_name}opsmanager"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  location            = "${var.location}"
-  account_type        = "Premium_LRS"
+  name                     = "${var.env_short_name}opsmanager"
+  resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
+  location                 = "${var.location}"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_container" "ops_manager_storage_container" {
@@ -59,10 +61,11 @@ resource "azurerm_storage_table" "stemcells_storage_table" {
 }
 
 resource "azurerm_storage_account" "bosh_vms_storage_account" {
-  name                = "${var.env_short_name}${data.template_file.base_storage_account_wildcard.rendered}${count.index}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  location            = "${var.location}"
-  account_type        = "Premium_LRS"
+  name                     = "${var.env_short_name}${data.template_file.base_storage_account_wildcard.rendered}${count.index}"
+  resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
+  location                 = "${var.location}"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
 
   count = 5
 }
@@ -90,10 +93,11 @@ resource "azurerm_storage_container" "bosh_vms_stemcell_storage_container" {
 # Storage containers to be used as CF Blobstore
 
 resource "azurerm_storage_account" "cf_storage_account" {
-  name                = "${var.env_short_name}cf"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
-  location            = "${var.location}"
-  account_type        = "Standard_LRS"
+  name                     = "${var.env_short_name}cf"
+  resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_container" "cf_buildpacks_storage_container" {


### PR DESCRIPTION
Hi,

This change mirrors the change to the terraforming-gcp so that our tooling does not need to know about both names.

It also updates the storage templates for terraform v0.10.8.

Thanks!
@davewalter and @madamkiwi