### PR TITLE
Add optional ssl cert properties

### DIFF
--- a/isolation_segment/outputs.tf
+++ b/isolation_segment/outputs.tf
@@ -1,3 +1,13 @@
 output "lb_name" {
   value = "${element(concat(azurerm_lb.iso.*.name, list("")), 0)}"
 }
+
+output "ssl_cert" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+}
+
+output "ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
+}

--- a/isolation_segment/self_signed_certs.tf
+++ b/isolation_segment/self_signed_certs.tf
@@ -1,0 +1,43 @@
+resource "tls_cert_request" "ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.iso.${var.dns_zone}",
+  ]
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.dns_zone}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.ssl_ca_private_key}"
+  ca_cert_pem        = "${var.ssl_ca_cert}"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+}

--- a/isolation_segment/variables.tf
+++ b/isolation_segment/variables.tf
@@ -15,3 +15,27 @@ variable "resource_group_name" {
 variable "dns_zone" {
   type = "string"
 }
+
+variable "ssl_cert" {
+  type        = "string"
+  description = "the contents of an SSL certificate which should be passed to the isoseg gorouter, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_private_key" {
+  type        = "string"
+  description = "the contents of an SSL private key which should be passed to the isoseg gorouter, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign a generated certificate for isoseg gorouter, optional if `ssl_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign a generated certificate for isoseg gorouter, optional if `ssl_cert` is provided"
+  default     = ""
+}

--- a/modules.tf
+++ b/modules.tf
@@ -7,4 +7,9 @@ module "isolation_segment" {
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
   dns_zone            = "${azurerm_dns_zone.env_dns_zone.name}"
+
+  ssl_cert           = "${var.iso_seg_ssl_cert}"
+  ssl_private_key    = "${var.iso_seg_ssl_private_key}"
+  ssl_ca_cert        = "${var.iso_seg_ssl_ca_cert}"
+  ssl_ca_private_key = "${var.iso_seg_ssl_ca_private_key}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,6 +46,26 @@ output "env_dns_zone_name_servers" {
   value = "${azurerm_dns_zone.env_dns_zone.name_servers}"
 }
 
+output "ssl_cert" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+}
+
+output "ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
+}
+
+output "iso_seg_ssl_cert" {
+  sensitive = true
+  value     = "${module.isolation_segment.ssl_cert}"
+}
+
+output "iso_seg_ssl_private_key" {
+  sensitive = true
+  value     = "${module.isolation_segment.ssl_private_key}"
+}
+
 output "web_lb_name" {
   value = "${azurerm_lb.web.name}"
 }
@@ -148,7 +168,7 @@ output "cf_buildpacks_storage_container" {
 
 output "ops_manager_ssh_public_key" {
   sensitive = true
-  value    = "${tls_private_key.ops_manager.public_key_openssh}"
+  value     = "${tls_private_key.ops_manager.public_key_openssh}"
 }
 
 output "ops_manager_ssh_private_key" {

--- a/self_signed_certs.tf
+++ b/self_signed_certs.tf
@@ -1,0 +1,44 @@
+resource "tls_cert_request" "ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.apps.${var.env_name}.${var.dns_suffix}",
+    "*.sys.${var.env_name}.${var.dns_suffix}",
+  ]
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.env_name}.${var.dns_suffix}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.ssl_ca_private_key}"
+  ca_cert_pem        = "${var.ssl_ca_cert}"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,30 @@ variable "client_secret" {}
 
 variable "location" {}
 
+variable "ssl_cert" {
+  type        = "string"
+  description = "the contents of an SSL certificate which should be passed to the gorouter, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_private_key" {
+  type        = "string"
+  description = "the contents of an SSL private key which should be passed to the gorouter, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign a generated certificate for gorouter, optional if `ssl_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign a generated certificate for gorouter, optional if `ssl_cert` is provided"
+  default     = ""
+}
+
 variable "ops_manager_image_uri" {}
 
 variable "optional_ops_manager_image_uri" {
@@ -31,4 +55,28 @@ variable "dns_suffix" {}
 
 variable "isolation_segment" {
   default = false
+}
+
+variable "iso_seg_ssl_cert" {
+  type        = "string"
+  description = "the contents of an SSL certificate which should be passed to the iso seg gorouter, optional if `iso_seg_ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "iso_seg_ssl_private_key" {
+  type        = "string"
+  description = "the contents of an SSL private key which should be passed to the iso seg gorouter, optional if `iso_seg_ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "iso_seg_ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign a generated certificate for iso seg gorouter, optional if `iso_seg_ssl_cert` is provided"
+  default     = ""
+}
+
+variable "iso_seg_ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign a generated certificate for iso seg gorouter, optional if `iso_seg_ssl_cert` is provided"
+  default     = ""
 }


### PR DESCRIPTION
- Adds ssl_cert/private_key inputs and ouputs
  - If specifed, these keys are passed thru as an output
  - The user can then pass this output to the gorouter BOSH manifest
- If ssl_ca_cert/private_key is provided, the templates will generate a
  self-signed SSL cert with hostnames for `*.apps.DOMAIN` and `*.sys.DOMAIN`
- Adds similar properties for iso seg module

[#151189254]