### PR TITLE
Standardise the tcp_domain output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "mysql_dns" {
   value = "mysql.${azurerm_dns_a_record.mysql.zone_name}"
 }
 
-output "tcp_dns" {
+output "tcp_domain" {
   value = "tcp.${azurerm_dns_a_record.tcp.zone_name}"
 }
 


### PR DESCRIPTION
Hi

This PR standardises the tcp_domain output name to match the corresponding output in the AWS and GCP templates.

Thanks!
Kevin and @davewalter 