### PR TITLE
Add optional_ops_manager_public_ip to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -196,6 +196,10 @@ output "ops_manager_ip" {
   value = "${azurerm_public_ip.ops_manager_public_ip.ip_address}"
 }
 
+output "optional_ops_manager_public_ip" {
+  value = "${azurerm_public_ip.optional_ops_manager_public_ip.ip_address}"
+}
+
 output "ops_manager_private_ip" {
   value = "${azurerm_network_interface.ops_manager_nic.private_ip_address}"
 }


### PR DESCRIPTION
- This provides more feature pairity and follows patterns in [terraforming-gcp](https://github.com/pivotal-cf/terraforming-gcp/blob/0736b124841d5b5b960741b0b4bdc333365a1f9c/outputs.tf#L46-L48)
- This is needed by the OpsManager CI for upgrade integration tests (AKA system specs.)

Signed-off-by: Tom Dunlap <tdunlap@pivotal.io>