### PR TITLE
removed `-pcf-resource-group` suffix.

### DIFF
--- a/resource_group.tf
+++ b/resource_group.tf
@@ -1,4 +1,4 @@
 resource "azurerm_resource_group" "pcf_resource_group" {
-  name     = "${var.env_name}-pcf-resource-group"
+  name     = "${var.env_name}"
   location = "${var.location}"
 }


### PR DESCRIPTION
this doesn't need to be there. if you use `pcf` as your `env_name`, you
get `pcf-pcf-resource-group`, and that name gets carried throughout the
rest of the resource group. this will let you pick a name like `pcf`
and then everything is just referenced as `pcf-<resource>` throughout
the rest of the object creation process.

Signed-off-by: Mike Lloyd <mike@reboot3times.org>