### PR TITLE
support using cloud environments

### DIFF
--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -3,6 +3,7 @@ provider "azurerm" {
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"
   tenant_id       = "${var.tenant_id}"
+  environment     = "${var.cloud_name}"
 }
 
 terraform {

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -1,5 +1,10 @@
 variable "env_name" {}
 
+variable "cloud_name" {
+  description "The Azure cloud environment to use. Available values at https://www.terraform.io/docs/providers/azurerm/#environment"
+  default "public"
+}
+
 variable "env_short_name" {
   description = "Used for creating storage accounts. Must be a-z only, no longer than 10 characters"
 }


### PR DESCRIPTION
This enables the terraform to use different cloud environments, such as Azure Germany.
The values are based of https://www.terraform.io/docs/providers/azurerm/#environment.
The variable `cloud_name` was used because `env` is already overloaded for OpsMan and PCF usage.
The default `cloud_name` is just using the US cloud environment, the original default of the terraform provider