### PR TITLE
Refactored subnets to use NSG associations

### DIFF
--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -244,6 +244,10 @@ resource "azurerm_subnet" "infrastructure_subnet" {
   resource_group_name       = "${azurerm_resource_group.pcf_resource_group.name}"
   virtual_network_name      = "${azurerm_virtual_network.pcf_virtual_network.name}"
   address_prefix            = "${var.pcf_infrastructure_subnet}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "ops_manager_security_group" {
+  subnet_id                 = "${azurerm_subnet.infrastructure_subnet.id}"
   network_security_group_id = "${azurerm_network_security_group.ops_manager_security_group.id}"
 }
 

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -7,6 +7,10 @@ resource "azurerm_subnet" "pas_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.pas_subnet_cidr}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "pas_subnet" {
+  subnet_id                 = "${azurerm_subnet.pas_subnet.id}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
@@ -17,6 +21,10 @@ resource "azurerm_subnet" "services_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.services_subnet_cidr}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "services_subnet" {
+  subnet_id                 = "${azurerm_subnet.services_subnet.id}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
@@ -27,5 +35,9 @@ resource "azurerm_subnet" "dynamic_services_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.dynamic_services_subnet_cidr}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "dynamic_services_subnet" {
+  subnet_id                 = "${azurerm_subnet.dynamic_services_subnet.id}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }


### PR DESCRIPTION
Cleaned up subnet definitions to use subnet network security group
associations as azurerm_subnet.network_security_group_id is being
deprecated.