### PR TITLE
Bumped up TCP idle timeout settings

### DIFF
--- a/modules/pas/weblb.tf
+++ b/modules/pas/weblb.tf
@@ -4,6 +4,7 @@ resource "azurerm_public_ip" "web-lb-public-ip" {
   resource_group_name          = "${var.resource_group_name}"
   public_ip_address_allocation = "static"
   sku                          = "Standard"
+  idle_timeout_in_minutes      = 30
 }
 
 resource "azurerm_lb" "web" {
@@ -41,6 +42,7 @@ resource "azurerm_lb_rule" "web-https-rule" {
   protocol                       = "TCP"
   frontend_port                  = 443
   backend_port                   = 443
+  idle_timeout_in_minutes        = 30
 
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.web-backend-pool.id}"
   probe_id                = "${azurerm_lb_probe.web-https-probe.id}"
@@ -63,6 +65,7 @@ resource "azurerm_lb_rule" "web-http-rule" {
   protocol                       = "TCP"
   frontend_port                  = 80
   backend_port                   = 80
+  idle_timeout_in_minutes        = 30
 
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.web-backend-pool.id}"
   probe_id                = "${azurerm_lb_probe.web-http-probe.id}"


### PR DESCRIPTION
Increased the TCP idle timeout setting for web-lb-public-ip,
web-https-rule and web-http-rule to remedy issues in Azure
relating to network connections closing pre-maturely when
used in conjunction with Spring Cloud Services.

More info:
https://docs.pivotal.io/spring-cloud-services/1-5/smoke-tests.html