### PR TITLE
Remove unused storage account

### DIFF
--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -257,11 +257,6 @@ locals {
   dns_subdomain = "${var.env_name}"
 }
 
-// the CPI uses this as a wildcard to stripe disks across multiple storage accounts
-data "template_file" "base_storage_account_wildcard" {
-  template = "boshvms"
-}
-
 resource "azurerm_dns_zone" "env_dns_zone" {
   name                = "${var.dns_subdomain != "" ? var.dns_subdomain : local.dns_subdomain}.${var.dns_suffix}"
   resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
@@ -313,8 +308,4 @@ output "bosh_deployed_vms_security_group_id" {
 
 output "bosh_deployed_vms_security_group_name" {
   value = "${azurerm_network_security_group.bosh_deployed_vms_security_group.name}"
-}
-
-output "wildcard_vm_storage_account" {
-  value = "*${var.env_short_name}${data.template_file.base_storage_account_wildcard.rendered}*"
 }

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -160,10 +160,6 @@ output "ops_manager_storage_account" {
   value = "${module.ops_manager.ops_manager_storage_account}"
 }
 
-output "wildcard_vm_storage_account" {
-  value = "${module.infra.wildcard_vm_storage_account}"
-}
-
 output "cf_storage_account_name" {
   value = "${module.pas.cf_storage_account_name}"
 }

--- a/terraforming-pks/outputs.tf
+++ b/terraforming-pks/outputs.tf
@@ -84,10 +84,6 @@ output "ops_manager_storage_account" {
   value = "${module.ops_manager.ops_manager_storage_account}"
 }
 
-output "wildcard_vm_storage_account" {
-  value = "${module.infra.wildcard_vm_storage_account}"
-}
-
 output "ops_manager_ssh_public_key" {
   sensitive = true
   value     = "${module.ops_manager.ops_manager_ssh_public_key}"


### PR DESCRIPTION
When the change was made to move from storage accounts to managed disks, `wildcard_vm_storage_account` this was left behind. There's no need for multiple storage accounts or a wildcarded storage account when using managed disks.

Previously this value was used like so in the director config:
```yaml
iaas-configuration:
  cloud_storage_type: storage_accounts
  deployments_storage_account_name: ((wildcard_vm_storage_account))
```

but now it's not used and looks like this:
```yaml
iaas-configuration:
  storage_account_type: Premium_LRS
  cloud_storage_type: managed_disks
```