### PR TITLE
Add auto-generated unique storage account names

### DIFF
--- a/modules/infra/bosh.tf
+++ b/modules/infra/bosh.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "bosh_root_storage_account" {
-  name                     = "${var.env_short_name}director"
+  name                     = "${var.storage_account_prefix}director${var.storage_account_suffix}"
   resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
   location                 = "${var.location}"
   account_tier             = "Standard"

--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -2,7 +2,11 @@ variable "env_name" {
   default = ""
 }
 
-variable "env_short_name" {
+variable "storage_account_prefix" {
+  default = ""
+}
+
+variable "storage_account_suffix" {
   default = ""
 }
 

--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -4,7 +4,11 @@ variable "env_name" {
   default = ""
 }
 
-variable "env_short_name" {
+variable "storage_account_prefix" {
+  default = ""
+}
+
+variable "storage_account_suffix" {
   default = ""
 }
 
@@ -47,7 +51,7 @@ variable "dns_zone_name" {
 # ==================== Storage
 
 resource "azurerm_storage_account" "ops_manager_storage_account" {
-  name                     = "${var.env_short_name}opsmanager"
+  name                     = "${var.storage_account_prefix}opsmanager${var.storage_account_suffix}"
   resource_group_name      = "${var.resource_group_name}"
   location                 = "${var.location}"
   account_tier             = "Premium"

--- a/modules/pas/storage.tf
+++ b/modules/pas/storage.tf
@@ -1,7 +1,7 @@
 # Storage containers to be used as CF Blobstore
 
 resource "azurerm_storage_account" "cf_storage_account" {
-  name                     = "${var.env_short_name}${var.cf_storage_account_name}"
+  name                     = "${var.cf_storage_account_prefix}${var.cf_storage_account_name}${var.cf_storage_account_suffix}"
   resource_group_name      = "${var.resource_group_name}"
   location                 = "${var.location}"
   account_tier             = "Standard"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -1,5 +1,4 @@
 variable "env_name" {}
-variable "env_short_name" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "dns_zone_name" {}
@@ -9,6 +8,8 @@ variable "cf_droplets_storage_container_name" {}
 variable "cf_packages_storage_container_name" {}
 variable "cf_resources_storage_container_name" {}
 variable "cf_storage_account_name" {}
+variable "cf_storage_account_prefix" {}
+variable "cf_storage_account_suffix" {}
 
 variable "network_name" {}
 variable "pas_subnet_cidr" {}


### PR DESCRIPTION
This ensures likely globally unique storage account names that are still human readable.

1. Ensure the environment short name is less than 10 chars
2. Generate a unique storage account suffix string of 4 chars

Azure storage accounts can be at most 24 characters in length. 10 + 4 leaves a total of 10 chars for each storage account with the longest currently being 'opsmanager'. Example generated storage account name: `sandboxopsmanagerpit7`.

An alternative and simpler implementation is to generate 16 byte unique ids (random_id resource) as the storage account names and drop the human readability. An operator could still identify the storage accounts by resource group, however it would be difficult to tell the difference between the storage account types, i.e. director vs opsmanager etc.