### PR TITLE
Add additional attributes to avoid Terraform updating infrastructure

### DIFF
--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -235,11 +235,12 @@ resource "azurerm_virtual_network" "pcf_virtual_network" {
 }
 
 resource "azurerm_subnet" "infrastructure_subnet" {
-  name                 = "${var.env_name}-infrastructure-subnet"
-  depends_on           = ["azurerm_resource_group.pcf_resource_group"]
-  resource_group_name  = "${azurerm_resource_group.pcf_resource_group.name}"
-  virtual_network_name = "${azurerm_virtual_network.pcf_virtual_network.name}"
-  address_prefix       = "${var.pcf_infrastructure_subnet}"
+  name                      = "${var.env_name}-infrastructure-subnet"
+  depends_on                = ["azurerm_resource_group.pcf_resource_group"]
+  resource_group_name       = "${azurerm_resource_group.pcf_resource_group.name}"
+  virtual_network_name      = "${azurerm_virtual_network.pcf_virtual_network.name}"
+  address_prefix            = "${var.pcf_infrastructure_subnet}"
+  network_security_group_id = "${azurerm_network_security_group.ops_manager_security_group.id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "ops_manager_security_group" {

--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -76,6 +76,7 @@ resource "azurerm_storage_blob" "ops_manager_image" {
   storage_container_name = "${azurerm_storage_container.ops_manager_storage_container.name}"
   source_uri             = "${var.ops_manager_image_uri}"
   count                  = "${var.vm_count}"
+  type                   = "page"
 }
 
 resource "azurerm_image" "ops_manager_image" {

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -7,6 +7,7 @@ resource "azurerm_subnet" "pas_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.pas_subnet_cidr}"
+  network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "pas_subnet" {
@@ -21,6 +22,7 @@ resource "azurerm_subnet" "services_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.services_subnet_cidr}"
+  network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "services_subnet" {


### PR DESCRIPTION
Fix the Terraform templates so they can be run multiple times without needing to run apply every time.

The `azurerm_storage_blob.ops_manager_image.page` attribute tries to reset itself to `""` from `"page"` (the default). Here's the Terraform plan on subsequent runs, notice it wants to rebuild opsman.

```
-/+ module.ops_manager.azurerm_image.ops_manager_image (new resource required)
...
-/+ module.ops_manager.azurerm_storage_blob.ops_manager_image (new resource required)
      id:                                                               "https://sboxopsmanager.blob.core.windows.net/opsmanagerimage/opsman.vhd" => <computed> (forces new resource)
      attempts:                                                         "1" => "1"
      content_type:                                                     "application/octet-stream" => "application/octet-stream"
      name:                                                             "opsman.vhd" => "opsman.vhd"
      parallelism:                                                      "8" => "8"
      resource_group_name:                                              "sbox" => "sbox"
      size:                                                             "0" => "0"
      source_uri:                                                       "https://opsmanagerwestus.blob.core.windows.net/images/ops-manager-2.3-build.188.vhd" => "https://opsmanagerwestus.blob.core.windows.net/images/ops-manager-2.3-build.188.vhd"
      storage_account_name:                                             "sboxopsmanager" => "sboxopsmanager"
      storage_container_name:                                           "opsmanagerimage" => "opsmanagerimage"
      type:                                                             "page" => "" (forces new resource)
      url:                                                              "https://sboxopsmanager.blob.core.windows.net/opsmanagerimage/opsman.vhd" => <computed>
-/+ module.ops_manager.azurerm_virtual_machine.ops_manager_vm (new resource required)
...
```

The `azurerm_subnet.*.network_security_group_id` tries to reset itself to empty string, even though it's deprecated and set in another resource. The following commit introduced this: 1ce23822ef8b9175d1ebb823b44b2c8672aa2081. While the [network_security_group_id attribute is deprecated](https://www.terraform.io/docs/providers/azurerm/r/subnet.html#network_security_group_id) and causes warnings, setting it in _addition_ to using the `azurerm_subnet_network_security_group_association` resource avoids unnecessary infrastructure changes.

```
~ module.infra.azurerm_subnet.infrastructure_subnet
    network_security_group_id: "/subscriptions/GUID/resourceGroups/sbox/providers/Microsoft.Network/networkSecurityGroups/sbox-ops-manager-security-group" => ""
```
