### PR TITLE
Adds managed identities for Azure master and worker nodes

### DIFF
--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -1,13 +1,3 @@
-provider "azurerm" {
-  subscription_id = "${var.subscription_id}"
-  client_id       = "${var.client_id}"
-  client_secret   = "${var.client_secret}"
-  tenant_id       = "${var.tenant_id}"
-  environment     = "${var.cloud_name}"
-
-  version = "~> 1.22"
-}
-
 terraform {
   required_version = "< 0.12.0"
 }
@@ -61,4 +51,86 @@ module "pks" {
 
   resource_group_name = "${module.infra.resource_group_name}"
   network_name        = "${module.infra.network_name}"
+}
+
+provider "azurerm" {
+  subscription_id = "${var.subscription_id}"
+  client_id       = "${var.client_id}"
+  client_secret   = "${var.client_secret}"
+  tenant_id       = "${var.tenant_id}"
+  environment     = "${var.cloud_name}"
+
+  version = "~> 1.22"
+}
+
+data "azurerm_subscription" "primary" {}
+
+resource "azurerm_role_definition" "pks_master_role" {
+  name        = "${var.env_name}-pks-master-role"
+  scope       = "${data.azurerm_subscription.primary.id}"
+  description = "This is a custom role created via Terraform"
+
+  permissions {
+    actions     = [
+      "Microsoft.Network/*",
+      "Microsoft.Compute/disks/*",
+      "Microsoft.Compute/virtualMachines/write",
+      "Microsoft.Compute/virtualMachines/read",
+      "Microsoft.Storage/storageAccounts/*"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    "${data.azurerm_subscription.primary.id}/resourceGroups/${var.env_name}",
+  ]
+}
+
+resource "azurerm_role_definition" "pks_worker_role" {
+  name        = "${var.env_name}-pks-worker-role"
+  scope       = "${data.azurerm_subscription.primary.id}"
+  description = "This is a custom role created via Terraform"
+
+  permissions {
+    actions     = [
+      "Microsoft.Storage/storageAccounts/*"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    "${data.azurerm_subscription.primary.id}/resourceGroups/${var.env_name}",
+  ]
+}
+
+resource "azurerm_user_assigned_identity" "pks_master_identity" {
+  resource_group_name = "${module.infra.resource_group_name}"
+  location            = "${var.location}"
+
+  name = "pks-master"
+}
+
+resource "azurerm_role_assignment" "master_role_assignemnt" {
+  scope              = "${data.azurerm_subscription.primary.id}/resourceGroups/${var.env_name}"
+  role_definition_id = "${azurerm_role_definition.pks_master_role.id}"
+  principal_id       = "${azurerm_user_assigned_identity.pks_master_identity.principal_id}"
+}
+
+resource "azurerm_user_assigned_identity" "pks_worker_identity" {
+  resource_group_name = "${module.infra.resource_group_name}"
+  location            = "${var.location}"
+
+  name = "pks-worker"
+}
+
+resource "azurerm_role_assignment" "worker_role_assignemnt" {
+  scope              = "${data.azurerm_subscription.primary.id}/resourceGroups/${var.env_name}"
+  role_definition_id = "${azurerm_role_definition.pks_worker_role.id}"
+  principal_id       = "${azurerm_user_assigned_identity.pks_worker_identity.principal_id}"
+}
+
+resource "azurerm_availability_set" "pks" {
+  name                = "${var.env_name}-availability-set"
+  location            = "${var.location}"
+  resource_group_name = "${module.infra.resource_group_name}"
 }

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -85,3 +85,13 @@ variable "ssl_cert" {
 variable "ssl_private_key" {
   default = ""
 }
+
+variable "azure_master_managed_identity" {
+  type = "string"
+  default = "pks-master"
+}
+
+variable "azure_worker_managed_identity" {
+  type = "string"
+  default = "pks-worker"
+}


### PR DESCRIPTION
Need these changes ASAP in hopes of meeting our deadlines for PKS 1.3 (code freeze is dec 19 ish). 

We need them in order to deploy our own Azure environments with managed identities so that new Azure features that are going to be PR'ed by OD-PKS can reference those identities.

We tested these changes by terraform applying them and successfully creating a new Azure environment.

    [#162644445]

- @bryaneburr and Maryam

See this story for context on this change: https://www.pivotaltracker.com/story/show/162644445
