### PR TITLE
Fixed public IP SKUs and allocation methods

### DIFF
--- a/modules/isolation_segment/load_balancer.tf
+++ b/modules/isolation_segment/load_balancer.tf
@@ -3,7 +3,8 @@ resource "azurerm_public_ip" "iso-lb-public-ip" {
   count                        = "${var.count}"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
+  sku                          = "Standard"
 }
 
 resource "azurerm_lb" "iso" {

--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -105,10 +105,11 @@ resource "azurerm_dns_a_record" "optional_ops_manager_dns" {
 # ==================== VMs
 
 resource "azurerm_public_ip" "ops_manager_public_ip" {
-  name                         = "${var.env_name}-ops-manager-public-ip"
+  name                         = "ops-manager-public-ip"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
+  sku                          = "Standard"
 }
 
 resource "azurerm_network_interface" "ops_manager_nic" {

--- a/modules/pas/diegosshlb.tf
+++ b/modules/pas/diegosshlb.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "diego-ssh-lb-public-ip" {
   name                         = "diego-ssh-lb-public-ip"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 

--- a/modules/pas/tcplb.tf
+++ b/modules/pas/tcplb.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "tcp-lb-public-ip" {
   name                         = "tcp-lb-public-ip"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 

--- a/modules/pas/weblb.tf
+++ b/modules/pas/weblb.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "web-lb-public-ip" {
   name                         = "web-lb-public-ip"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
   idle_timeout_in_minutes      = 30
 }

--- a/modules/pks/lb.tf
+++ b/modules/pks/lb.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "pks-lb-ip" {
   name                         = "${var.env_id}-pks-lb-ip"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 


### PR DESCRIPTION
- Fixed #41  public IP SKUs and allocation methods Adding SKU type to Ops Manager Public IP. 
- Updates allocation_method for public_ips to clean up use of deprecated public_ip_address_allocation method.
- Normalizes Ops Manager Public IP name to align public_ip naming standards.