### PR TITLE
Only create NIC if an Ops Manager VM is created

### DIFF
--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -117,6 +117,7 @@ resource "azurerm_network_interface" "ops_manager_nic" {
   location                  = "${var.location}"
   resource_group_name       = "${var.resource_group_name}"
   network_security_group_id = "${var.security_group_id}"
+  count                     = "${var.vm_count}"
 
   ip_configuration {
     name                          = "${var.env_name}-ops-manager-ip-config"


### PR DESCRIPTION
Attempting to use the external IP address created by terraform with a different VM management tool fails if that resource is bound to a NIC, and the azure command line tool doesn't offer an easy way to use an existing NIC. So, to use the IP address provisioned by terraform, we need the NIC to not exist.