### PR TITLE
Sets the opsman_image blob to type page

### DIFF
--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -76,6 +76,7 @@ resource "azurerm_storage_blob" "ops_manager_image" {
   storage_container_name = "${azurerm_storage_container.ops_manager_storage_container.name}"
   source_uri             = "${var.ops_manager_image_uri}"
   count                  = "${var.vm_count}"
+  type                   = "page"
 }
 
 resource "azurerm_image" "ops_manager_image" {


### PR DESCRIPTION
Adding the `type = "page"` on the storage_blob prevents terraform from re-downloading the opsman image every time.