### PR TITLE
Allows opsman A record to be configured

### DIFF
--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -48,7 +48,7 @@ resource "azurerm_image" "ops_manager_image" {
 # ==================== DNS
 
 resource "azurerm_dns_a_record" "ops_manager_dns" {
-  name                = "pcf"
+  name                = "${var.ops_manager_a_record}"
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"
@@ -56,7 +56,7 @@ resource "azurerm_dns_a_record" "ops_manager_dns" {
 }
 
 resource "azurerm_dns_a_record" "optional_ops_manager_dns" {
-  name                = "pcf-optional"
+  name                = "${var.ops_manager_a_record}-optional"
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -20,6 +20,10 @@ variable "ops_manager_vm_size" {
   default = ""
 }
 
+variable "ops_manager_a_record" {
+  default = ""
+}
+
 variable "resource_group_name" {
   default = ""
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -32,6 +32,7 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_a_record   = "${var.ops_manager_a_record}"
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -42,6 +42,12 @@ variable "ops_manager_vm_size" {
   default = "Standard_DS2_v2"
 }
 
+variable "ops_manager_a_record" {
+  type        = "string"
+  description = "The A record to associate with the Ops Manager VM. For example, if your ops_manager_a_record is `pcf`, and your dns_suffix is `pivotal.io`, your Opsman domain would be `pcf.pivotal.io`"
+  default     = "pcf"
+}
+
 variable "optional_ops_manager_image_uri" {
   default = ""
 }

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -32,6 +32,7 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_a_record   = "${var.ops_manager_a_record}"
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -89,6 +89,12 @@ variable "ops_manager_vm_size" {
   default = "Standard_DS2_v2"
 }
 
+variable "ops_manager_a_record" {
+  type        = "string"
+  description = "The A record to associate with the Ops Manager VM. For example, if your ops_manager_a_record is `pcf`, and your dns_suffix is `pivotal.io`, your Opsman domain would be `pcf.pivotal.io`"
+  default     = "pcf"
+}
+
 variable "dns_suffix" {}
 
 variable "dns_subdomain" {

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -31,6 +31,7 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_a_record   = "${var.ops_manager_a_record}"
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -70,6 +70,12 @@ variable "ops_manager_private_ip" {
   default     = "10.0.8.4"
 }
 
+variable "ops_manager_a_record" {
+  type        = "string"
+  description = "The A record to associate with the Ops Manager VM. For example, if your ops_manager_a_record is `pcf`, and your dns_suffix is `pivotal.io`, your Opsman domain would be `pcf.pivotal.io`"
+  default     = "pcf"
+}
+
 variable "optional_ops_manager_image_uri" {
   default = ""
 }


### PR DESCRIPTION
Adds a variable to allow the A record for opsman to be configured to something other than `pcf`.