### PR TITLE
[PKS-CORE] Add bosh_deployed_vms_security_group to pks services subnet

### DIFF
--- a/modules/pks/networking.tf
+++ b/modules/pks/networking.tf
@@ -12,3 +12,8 @@ resource "azurerm_subnet" "pks_services" {
   virtual_network_name = "${var.network_name}"
   address_prefix       = "${local.pks_services_cidr}"
 }
+
+resource "azurerm_subnet_network_security_group_association" "pks_services" {
+  subnet_id                 = "${azurerm_subnet.pks_services.id}"
+  network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
+}

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -14,3 +14,7 @@ locals {
   pks_cidr          = "${cidrsubnet(var.resource_group_cidr, 6, 3)}"
   pks_services_cidr = "${cidrsubnet(var.resource_group_cidr, 6, 4)}"
 }
+
+variable "bosh_deployed_vms_security_group_id" {
+  default = ""
+}

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -15,6 +15,4 @@ locals {
   pks_services_cidr = "${cidrsubnet(var.resource_group_cidr, 6, 4)}"
 }
 
-variable "bosh_deployed_vms_security_group_id" {
-  default = ""
-}
+variable "bosh_deployed_vms_security_group_id" {}

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -61,4 +61,5 @@ module "pks" {
 
   resource_group_name = "${module.infra.resource_group_name}"
   network_name        = "${module.infra.network_name}"
+  bosh_deployed_vms_security_group_id = "${module.infra.bosh_deployed_vms_security_group_id}"
 }


### PR DESCRIPTION
Hi all, I'm from PKS-CORE team, we found one issue with the azure terraform script.
In order to get PKS loadbalancer working on Azure, the `bosh_deployed_vms_security_group` needs to be added to the `pks-services-network`.

I ran the terraform manually and verified that the security group did get added to the services-network

This blocks both PKS-CORE and PKS-Releng team to create correct Azure environment