### PR TITLE
 Variabilize ops manager and control plane DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ location              = "West US"
 dns_suffix            = "domain.com"
 
 # optional. if left blank, will default to the pattern `env_name.dns_suffix`.
-dns_subdomain         = ""
+dns_subdomain          = ""
+# optional dns values. If left blank opsmanager is `pcf.env_name_dns_suffix` and control plane is `plane.env_name_dns_suffix` .
+control_plane_dns_name = ""
+ops_manager_dns_name   = ""
+
 ```
 
 ## Variables

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dns_suffix            = "domain.com"
 
 # optional. if left blank, will default to the pattern `env_name.dns_suffix`.
 dns_subdomain          = ""
-# optional dns values. If left blank opsmanager is `pcf.env_name_dns_suffix` and control plane is `plane.env_name_dns_suffix` .
+# optional dns values. If left blank opsmanager is `pcf.env_name.dns_suffix` and control plane is `plane.env_name.dns_suffix` .
 control_plane_dns_name = ""
 ops_manager_dns_name   = ""
 

--- a/modules/control_plane/main.tf
+++ b/modules/control_plane/main.tf
@@ -7,7 +7,7 @@ locals {
 
 resource "azurerm_dns_a_record" "plane" {
   resource_group_name = "${var.resource_group_name}"
-  name                = "${var.plane_dns_name}"
+  name                = "${var.control_plane_dns_name}"
   zone_name           = "${var.dns_zone_name}"
   ttl                 = "60"
   records             = ["${azurerm_public_ip.plane.ip_address}"]

--- a/modules/control_plane/main.tf
+++ b/modules/control_plane/main.tf
@@ -7,7 +7,7 @@ locals {
 
 resource "azurerm_dns_a_record" "plane" {
   resource_group_name = "${var.resource_group_name}"
-  name                = "plane"
+  name                = "${var.plane_dns_name}"
   zone_name           = "${var.dns_zone_name}"
   ttl                 = "60"
   records             = ["${azurerm_public_ip.plane.ip_address}"]

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -6,3 +6,6 @@ variable "location" {}
 variable "resource_group_name" {}
 variable "network_name" {}
 variable "postgres_username" {}
+variable "plane_dns_name" {
+  default = "plane"
+}

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -6,6 +6,6 @@ variable "location" {}
 variable "resource_group_name" {}
 variable "network_name" {}
 variable "postgres_username" {}
-variable "plane_dns_name" {
+variable "control_plane_dns_name" {
   default = "plane"
 }

--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -48,7 +48,7 @@ resource "azurerm_image" "ops_manager_image" {
 # ==================== DNS
 
 resource "azurerm_dns_a_record" "ops_manager_dns" {
-  name                = "pcf"
+  name                = "${var.ops_manager_dns_name}"
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"
@@ -56,7 +56,7 @@ resource "azurerm_dns_a_record" "ops_manager_dns" {
 }
 
 resource "azurerm_dns_a_record" "optional_ops_manager_dns" {
-  name                = "pcf-optional"
+  name                = "${var.ops_manager_dns_name}-optional"
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -36,6 +36,10 @@ variable "dns_zone_name" {
   default = ""
 }
 
+variable "ops_manager_dns_name" {
+  default = "pcf"
+}
+
 variable "optional_ops_manager_image_uri" {
   default = ""
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -32,6 +32,7 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_dns_name   = "${var.ops_manager_dns_name}"
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 
@@ -47,6 +48,7 @@ module "control_plane" {
   resource_group_name = "${module.infra.resource_group_name}"
   env_name            = "${var.env_name}"
   dns_zone_name       = "${module.infra.dns_zone_name}"
+  plane_dns_name      = "${var.plane_dns_name}"
   cidr                = "${var.plane_cidr}"
   network_name        = "${module.infra.network_name}"
 

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -45,12 +45,12 @@ module "ops_manager" {
 module "control_plane" {
   source = "../modules/control_plane"
 
-  resource_group_name = "${module.infra.resource_group_name}"
-  env_name            = "${var.env_name}"
-  dns_zone_name       = "${module.infra.dns_zone_name}"
-  plane_dns_name      = "${var.plane_dns_name}"
-  cidr                = "${var.plane_cidr}"
-  network_name        = "${module.infra.network_name}"
+  resource_group_name    = "${module.infra.resource_group_name}"
+  env_name               = "${var.env_name}"
+  dns_zone_name          = "${module.infra.dns_zone_name}"
+  control_plane_dns_name = "${var.control_plane_dns_name}"
+  cidr                   = "${var.plane_cidr}"
+  network_name           = "${module.infra.network_name}"
 
   postgres_username = "${var.postgres_username}"
 

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -33,7 +33,7 @@ variable "ops_manager_image_uri" {
 
 variable "ops_manager_private_ip" {
   type        = "string"
-  description = "IP for the Ops Manager instance if not deploying in the default infrasstructure subnet"
+  description = "IP for the Ops Manager instance if not deploying in the default infrastructure subnet"
   default     = "10.0.8.4"
 }
 

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -37,6 +37,10 @@ variable "ops_manager_private_ip" {
   default     = "10.0.8.4"
 }
 
+variable "ops_manager_dns_name" {
+  default = "pcf"
+}
+
 variable "ops_manager_vm_size" {
   type    = "string"
   default = "Standard_DS2_v2"
@@ -58,6 +62,10 @@ variable "pcf_virtual_network_address_space" {
 
 variable "plane_cidr" {
   default = "10.0.10.0/28"
+}
+
+variable "plane_dns_name" {
+  default = "plane"
 }
 
 variable "postgres_username" {

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -64,7 +64,7 @@ variable "plane_cidr" {
   default = "10.0.10.0/28"
 }
 
-variable "plane_dns_name" {
+variable "control_plane_dns_name" {
   default = "plane"
 }
 

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -32,6 +32,8 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_dns_name   = "${var.ops_manager_dns_name}"
+
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -34,7 +34,6 @@ module "ops_manager" {
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
   ops_manager_dns_name   = "${var.ops_manager_dns_name}"
 
-
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 
   resource_group_name = "${module.infra.resource_group_name}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -89,6 +89,10 @@ variable "ops_manager_vm_size" {
   default = "Standard_DS2_v2"
 }
 
+variable "ops_manager_dns_name" {
+  default = "pcf"
+}
+
 variable "dns_suffix" {}
 
 variable "dns_subdomain" {

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -31,6 +31,7 @@ module "ops_manager" {
   ops_manager_image_uri  = "${var.ops_manager_image_uri}"
   ops_manager_vm_size    = "${var.ops_manager_vm_size}"
   ops_manager_private_ip = "${var.ops_manager_private_ip}"
+  ops_manager_dns_name   = "${var.ops_manager_dns_name}"
 
   optional_ops_manager_image_uri = "${var.optional_ops_manager_image_uri}"
 

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -70,6 +70,10 @@ variable "ops_manager_private_ip" {
   default     = "10.0.8.4"
 }
 
+variable "ops_manager_dns_name" {
+  default = "pcf"
+}
+
 variable "optional_ops_manager_image_uri" {
   default = ""
 }


### PR DESCRIPTION
Making terraforming-azure less opionated about DNS names used for opsmanager and control plane. Many existing users utilize DNS names like opsman.foundation and concourse.foundation and would like to continue doing so without creating custom forks. 