### PR TITLE
Increase idle_timeout_in_minutes to 30 on ops manager public ip

### DIFF
--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -67,10 +67,11 @@ resource "azurerm_dns_a_record" "optional_ops_manager_dns" {
 # ==================== VMs
 
 resource "azurerm_public_ip" "ops_manager_public_ip" {
-  name                = "${var.env_name}-ops-manager-public-ip"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  allocation_method   = "Static"
+  name                    = "${var.env_name}-ops-manager-public-ip"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  allocation_method       = "Static"
+  idle_timeout_in_minutes = 30
 }
 
 resource "azurerm_network_interface" "ops_manager_nic" {


### PR DESCRIPTION
Large tiles like SRT can take a long time to decompress, often exceeding the default 4 minute timeout.