### PR TITLE
Use Quotes for interpolating Azure Secrets

### DIFF
--- a/ci/assets/template/director-config.yml
+++ b/ci/assets/template/director-config.yml
@@ -5,7 +5,7 @@ properties-configuration:
     subscription_id: {{.subscription_id}}
     tenant_id: {{.tenant_id}}
     client_id: {{.client_id}}
-    client_secret: {{.client_secret}}
+    client_secret: "{{.client_secret}}"
     resource_group_name: {{.pcf_resource_group_name}}
     bosh_storage_account_name: {{.bosh_root_storage_account}}
     ssh_public_key: {{.ops_manager_ssh_public_key}}


### PR DESCRIPTION
Azure Secrets use Strong Passwords for new versions of Pricipals, wich leads into interpolation Erros when not useing Quotes:
`template '/home/bottkars/pivotal-cf-terraforming-azure-300c625/ci/assets/template/director-config.yml' is not valid YAML/JSON: yaml: line 8: did not find expected alphabetic or numeric character
+ popd`