### PR TITLE
Add support for ops_manager_storage_account_access_key

### DIFF
--- a/modules/ops_manager/outputs.tf
+++ b/modules/ops_manager/outputs.tf
@@ -37,3 +37,4 @@ output "ops_manager_storage_account" {
 output "ops_manager_storage_account_access_key" {
   sensitive = true
   value     = "${azurerm_storage_account.ops_manager_storage_account.primary_access_key}"
+}

--- a/modules/ops_manager/outputs.tf
+++ b/modules/ops_manager/outputs.tf
@@ -33,3 +33,7 @@ output "ops_manager_ssh_private_key" {
 output "ops_manager_storage_account" {
   value = "${azurerm_storage_account.ops_manager_storage_account.name}"
 }
+
+output "ops_manager_storage_account_access_key" {
+  sensitive = true
+  value     = "${azurerm_storage_account.ops_manager_storage_account.primary_access_key}"

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -149,7 +149,8 @@ output "ops_manager_storage_account" {
 }
 
 output "ops_manager_storage_account_access_key" {
-  value = "${module.ops_manager.ops_manager_storage_account_access_key}"
+  sensitive = true
+  value     = "${module.ops_manager.ops_manager_storage_account_access_key}"
 }
 
 output "cf_storage_account_name" {

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -148,6 +148,10 @@ output "ops_manager_storage_account" {
   value = "${module.ops_manager.ops_manager_storage_account}"
 }
 
+output "ops_manager_storage_account_access_key" {
+  value = "${module.ops_manager.ops_manager_storage_account_access_key}"
+}
+
 output "cf_storage_account_name" {
   value = "${module.pas.cf_storage_account_name}"
 }


### PR DESCRIPTION
In order to automate setting the ops_manager_storage_accout_access_key in pcf-automation, the key will need to be exposed via outputs.