### PR TITLE
Return azure location in outputs.tf

### DIFF
--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -2,6 +2,10 @@ output "iaas" {
   value = "azure"
 }
 
+output "location" {
+  value = "${var.location}"
+}
+
 output "subscription_id" {
   sensitive = true
   value     = "${var.subscription_id}"


### PR DESCRIPTION
Similar to iaas and subscription id, the azure location should be returned in the outputs.tf to make it easier to harvest for automation purposes. 