### PR TITLE
Enable Deployment or Dependency on a VNet in a Separate Resource Group

### DIFF
--- a/modules/infra/bosh.tf
+++ b/modules/infra/bosh.tf
@@ -6,7 +6,7 @@ resource random_string "bosh_storage_account_name" {
 
 resource "azurerm_storage_account" "bosh_root_storage_account" {
   name                     = "${random_string.bosh_storage_account_name.result}"
-  resource_group_name      = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name      = "${data.azurerm_resource_group.pcf_resource_group.name}"
   location                 = "${var.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
@@ -20,7 +20,7 @@ resource "azurerm_storage_account" "bosh_root_storage_account" {
 resource "azurerm_storage_container" "bosh_storage_container" {
   name                  = "bosh"
   depends_on            = ["azurerm_storage_account.bosh_root_storage_account"]
-  resource_group_name   = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name   = "${data.azurerm_resource_group.pcf_resource_group.name}"
   storage_account_name  = "${azurerm_storage_account.bosh_root_storage_account.name}"
   container_access_type = "private"
 }
@@ -28,14 +28,14 @@ resource "azurerm_storage_container" "bosh_storage_container" {
 resource "azurerm_storage_container" "stemcell_storage_container" {
   name                  = "stemcell"
   depends_on            = ["azurerm_storage_account.bosh_root_storage_account"]
-  resource_group_name   = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name   = "${data.azurerm_resource_group.pcf_resource_group.name}"
   storage_account_name  = "${azurerm_storage_account.bosh_root_storage_account.name}"
   container_access_type = "blob"
 }
 
 resource "azurerm_storage_table" "stemcells_storage_table" {
   name                 = "stemcells"
-  resource_group_name  = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name  = "${data.azurerm_resource_group.pcf_resource_group.name}"
   storage_account_name = "${azurerm_storage_account.bosh_root_storage_account.name}"
 }
 

--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -2,6 +2,10 @@ variable "env_name" {
   default = ""
 }
 
+variable "use_existing_rgs" {
+  default = false
+}
+
 variable "pcf_vnet_rg" {
   default = ""
 }
@@ -34,14 +38,30 @@ variable "pcf_infrastructure_subnet" {
   default = ""
 }
 
+locals {
+  pcf_network_rg_name = "${var.pcf_vnet_rg != "" ? var.pcf_vnet_rg : var.env_name}"
+}
+
 resource "azurerm_resource_group" "pcf_resource_group" {
+  count = "${var.use_existing_rgs ? "0" : "1"}"
   name     = "${var.env_name}"
   location = "${var.location}"
 }
 
+data "azurerm_resource_group" "pcf_resource_group" {
+  depends_on          = ["azurerm_resource_group.pcf_resource_group"]
+  name = "${var.env_name}"
+}
+
 resource "azurerm_resource_group" "pcf_network_rg" {
-  name = "${var.pcf_vnet_rg != "" ? var.pcf_vnet_rg : var.env_name}"
+  count = "${var.use_existing_rgs || var.pcf_vnet_rg != "" ? "0" : "1"}"
+  name = "${local.pcf_network_rg_name}"
   location = "${var.location}"
+}
+
+data "azurerm_resource_group" "pcf_network_rg" {
+  depends_on          = ["azurerm_resource_group.pcf_network_rg"]
+  name = "${local.pcf_network_rg_name}"
 }
 
 # ============== Security Groups ===============
@@ -49,7 +69,7 @@ resource "azurerm_resource_group" "pcf_network_rg" {
 resource "azurerm_network_security_group" "ops_manager_security_group" {
   name                = "${var.env_name}-ops-manager-security-group"
   location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
+  resource_group_name = "${data.azurerm_resource_group.pcf_network_rg.name}"
 
   security_rule {
     name                       = "ssh"
@@ -91,7 +111,7 @@ resource "azurerm_network_security_group" "ops_manager_security_group" {
 resource "azurerm_network_security_group" "bosh_deployed_vms_security_group" {
   name                = "${var.env_name}-bosh-deployed-vms-security-group"
   location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
+  resource_group_name = "${data.azurerm_resource_group.pcf_network_rg.name}"
 
   security_rule {
     name                       = "internal-anything"
@@ -245,8 +265,8 @@ resource "azurerm_network_security_group" "bosh_deployed_vms_security_group" {
 resource "azurerm_virtual_network" "pcf_virtual_network" {
   count               = "${var.create_vnet ? "1" : "0"}"
   name                = "${var.vnet_name != "" ? "${var.vnet_name}" : "${var.env_name}-virtual-network"}"
-  depends_on          = ["azurerm_resource_group.pcf_network_rg"]
-  resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
+  depends_on          = ["data.azurerm_resource_group.pcf_network_rg"]
+  resource_group_name = "${data.azurerm_resource_group.pcf_network_rg.name}"
   address_space       = "${var.pcf_virtual_network_address_space}"
   location            = "${var.location}"
 }
@@ -254,13 +274,13 @@ resource "azurerm_virtual_network" "pcf_virtual_network" {
 data "azurerm_virtual_network" "pcf_virtual_network" {
   name                = "${var.create_vnet ? "${var.vnet_name != "" ? "${var.vnet_name}" : "${var.env_name}-virtual-network"}" : "${var.vnet_name}"}"
   depends_on          = ["azurerm_virtual_network.pcf_virtual_network"]
-  resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
+  resource_group_name = "${data.azurerm_resource_group.pcf_network_rg.name}"
 }
 
 resource "azurerm_subnet" "infrastructure_subnet" {
   name                      = "${var.env_name}-infrastructure-subnet"
-  depends_on                = ["azurerm_resource_group.pcf_network_rg"]
-  resource_group_name       = "${azurerm_resource_group.pcf_network_rg.name}"
+  depends_on                = ["data.azurerm_resource_group.pcf_network_rg"]
+  resource_group_name       = "${data.azurerm_resource_group.pcf_network_rg.name}"
   virtual_network_name      = "${data.azurerm_virtual_network.pcf_virtual_network.name}"
   address_prefix            = "${var.pcf_infrastructure_subnet}"
   network_security_group_id = "${azurerm_network_security_group.ops_manager_security_group.id}"
@@ -279,7 +299,7 @@ locals {
 
 resource "azurerm_dns_zone" "env_dns_zone" {
   name                = "${var.dns_subdomain != "" ? var.dns_subdomain : local.dns_subdomain}.${var.dns_suffix}"
-  resource_group_name = "${azurerm_resource_group.pcf_resource_group.name}"
+  resource_group_name = "${data.azurerm_resource_group.pcf_resource_group.name}"
 }
 
 output "dns_zone_name" {
@@ -291,11 +311,11 @@ output "dns_zone_name_servers" {
 }
 
 output "resource_group_name" {
-  value = "${azurerm_resource_group.pcf_resource_group.name}"
+  value = "${data.azurerm_resource_group.pcf_resource_group.name}"
 }
 
 output "network_rg_name" {
-  value = "${azurerm_resource_group.pcf_network_rg.name}"
+  value = "${data.azurerm_resource_group.pcf_network_rg.name}"
 }
 
 output "network_name" {

--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -6,6 +6,10 @@ variable "pcf_vnet_rg" {
   default = ""
 }
 
+variable "create_vnet" {
+  default = true
+}
+
 variable "vnet_name" {
   default = ""
 }
@@ -239,6 +243,7 @@ resource "azurerm_network_security_group" "bosh_deployed_vms_security_group" {
 # ============= Networking
 
 resource "azurerm_virtual_network" "pcf_virtual_network" {
+  count               = "${var.create_vnet ? "1" : "0"}"
   name                = "${var.vnet_name != "" ? "${var.vnet_name}" : "${var.env_name}-virtual-network"}"
   depends_on          = ["azurerm_resource_group.pcf_network_rg"]
   resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
@@ -246,11 +251,17 @@ resource "azurerm_virtual_network" "pcf_virtual_network" {
   location            = "${var.location}"
 }
 
+data "azurerm_virtual_network" "pcf_virtual_network" {
+  name                = "${var.create_vnet ? "${var.vnet_name != "" ? "${var.vnet_name}" : "${var.env_name}-virtual-network"}" : "${var.vnet_name}"}"
+  depends_on          = ["azurerm_virtual_network.pcf_virtual_network"]
+  resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
+}
+
 resource "azurerm_subnet" "infrastructure_subnet" {
   name                      = "${var.env_name}-infrastructure-subnet"
   depends_on                = ["azurerm_resource_group.pcf_network_rg"]
   resource_group_name       = "${azurerm_resource_group.pcf_network_rg.name}"
-  virtual_network_name      = "${azurerm_virtual_network.pcf_virtual_network.name}"
+  virtual_network_name      = "${data.azurerm_virtual_network.pcf_virtual_network.name}"
   address_prefix            = "${var.pcf_infrastructure_subnet}"
   network_security_group_id = "${azurerm_network_security_group.ops_manager_security_group.id}"
 }
@@ -288,7 +299,7 @@ output "network_rg_name" {
 }
 
 output "network_name" {
-  value = "${azurerm_virtual_network.pcf_virtual_network.name}"
+  value = "${data.azurerm_virtual_network.pcf_virtual_network.name}"
 }
 
 output "infrastructure_subnet_id" {

--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -6,6 +6,10 @@ variable "pcf_vnet_rg" {
   default = ""
 }
 
+variable "vnet_name" {
+  default = ""
+}
+
 variable "location" {
   default = ""
 }
@@ -235,7 +239,7 @@ resource "azurerm_network_security_group" "bosh_deployed_vms_security_group" {
 # ============= Networking
 
 resource "azurerm_virtual_network" "pcf_virtual_network" {
-  name                = "${var.env_name}-virtual-network"
+  name                = "${var.vnet_name != "" ? "${var.vnet_name}" : "${var.env_name}-virtual-network"}"
   depends_on          = ["azurerm_resource_group.pcf_network_rg"]
   resource_group_name = "${azurerm_resource_group.pcf_network_rg.name}"
   address_space       = "${var.pcf_virtual_network_address_space}"

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -3,8 +3,8 @@
 resource "azurerm_subnet" "pas_subnet" {
   name = "${var.env_name}-pas-subnet"
 
-  //  depends_on                = ["${var.resource_group_name}"]
-  resource_group_name       = "${var.resource_group_name}"
+  //  depends_on                = ["${var.network_rg_name}"]
+  resource_group_name       = "${var.network_rg_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.pas_subnet_cidr}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
@@ -18,8 +18,8 @@ resource "azurerm_subnet_network_security_group_association" "pas_subnet" {
 resource "azurerm_subnet" "services_subnet" {
   name = "${var.env_name}-services-subnet"
 
-  //  depends_on                = ["${var.resource_group_name}"]
-  resource_group_name       = "${var.resource_group_name}"
+  //  depends_on                = ["${var.network_rg_name}"]
+  resource_group_name       = "${var.network_rg_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.services_subnet_cidr}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -1,6 +1,7 @@
 variable "env_name" {}
 variable "location" {}
 variable "resource_group_name" {}
+variable "network_rg_name" {}
 variable "dns_zone_name" {}
 
 variable "cf_buildpacks_storage_container_name" {}

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -17,6 +17,8 @@ module "infra" {
 
   env_name                          = "${var.env_name}"
   pcf_vnet_rg                       = "${var.pcf_vnet_rg}"
+  create_vnet                       = "${var.create_vnet}"
+  vnet_name                         = "${var.pcf_vnet_name}"
   location                          = "${var.location}"
   dns_subdomain                     = "${var.dns_subdomain}"
   dns_suffix                        = "${var.dns_suffix}"

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -16,6 +16,7 @@ module "infra" {
   source = "../modules/infra"
 
   env_name                          = "${var.env_name}"
+  use_existing_rgs                  = "${var.use_existing_rgs}"
   pcf_vnet_rg                       = "${var.pcf_vnet_rg}"
   create_vnet                       = "${var.create_vnet}"
   vnet_name                         = "${var.pcf_vnet_name}"

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -16,6 +16,7 @@ module "infra" {
   source = "../modules/infra"
 
   env_name                          = "${var.env_name}"
+  pcf_vnet_rg                       = "${var.pcf_vnet_rg}"
   location                          = "${var.location}"
   dns_subdomain                     = "${var.dns_subdomain}"
   dns_suffix                        = "${var.dns_suffix}"
@@ -57,6 +58,7 @@ module "pas" {
   cf_resources_storage_container_name  = "${var.cf_resources_storage_container_name}"
 
   resource_group_name                 = "${module.infra.resource_group_name}"
+  network_rg_name                     = "${module.infra.network_rg_name}"
   dns_zone_name                       = "${module.infra.dns_zone_name}"
   network_name                        = "${module.infra.network_name}"
   bosh_deployed_vms_security_group_id = "${module.infra.bosh_deployed_vms_security_group_id}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -149,3 +149,11 @@ variable "pcf_services_subnet" {
 variable "pcf_vnet_rg" {
   default = ""
 }
+
+variable "pcf_vnet_name" {
+  default = ""
+}
+
+variable "create_vnet" {
+  default = true
+}

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -146,6 +146,10 @@ variable "pcf_services_subnet" {
   default = "10.0.4.0/22"
 }
 
+variable "use_existing_rgs" {
+  default = false
+}
+
 variable "pcf_vnet_rg" {
   default = ""
 }

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -89,7 +89,8 @@ variable "ops_manager_vm_size" {
   default = "Standard_DS2_v2"
 }
 
-variable "dns_suffix" {}
+variable "dns_suffix" {
+}
 
 variable "dns_subdomain" {
   "type"        = "string"
@@ -143,4 +144,8 @@ variable "pcf_pas_subnet" {
 variable "pcf_services_subnet" {
   type    = "string"
   default = "10.0.4.0/22"
+}
+
+variable "pcf_vnet_rg" {
+  default = ""
 }


### PR DESCRIPTION
This enables networking resources to be deployed into a separate resource group. Ideally this will end up being networking resources pre-configured in an RG, provisioned by the IT department, with read only access for the Service Principal being used to deploy PAS/PKS/Control Plane.

Network Resources can optionally be deployed into a separate RG by:
- Setting `pcf_vnet_rg`, in tfvars, to the name of the RG where the network resources are to be deployed

The VNet here can optionally be pre-existing by:
- Setting `create_vnet = false` in tfvars
- Setting `pcf_vnet = "<name_of_existing_vnet>"` in tfvars

Features:
- Deploy network resources (VNet, subnets, NSGs) into a separate resource group
- Take a dependency on an existing VNet