### PR TITLE
Add a permission for worker role

### DIFF
--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -93,6 +93,7 @@ resource "azurerm_role_definition" "pks_worker_role" {
 
   permissions {
     actions = [
+      "Microsoft.Compute/virtualMachines/read",
       "Microsoft.Storage/storageAccounts/*"
     ]
     not_actions = []


### PR DESCRIPTION
Creating PVC fails due to insufficient role.

```
MountVolume.WaitForAttach failed for volume "pvc-8314a5c0-cd4e-11e9-b533-000d3a50a503" : compute.VirtualMachinesClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'b2152e70-6de6-4d27-802c-c62ef49bc6d3' with object id 'b2152e70-6de6-4d27-802c-c62ef49bc6d3' does not have authorization to perform action 'Microsoft.Compute/virtualMachines/read' over scope '/subscriptions/87ed685e-3efa-4b49-8149-48093de439ff/resourceGroups/m00650-0001-dev-je-rg/providers/Microsoft.Compute/virtualMachines/2f52412e-a5e6-4536-b018-f21432c08365' or the scope is invalid. If access was recently granted, please refresh your credentials."
```

Azure requires "Microsoft.Compute/virtualMachines/read" for k8s workers.